### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     name: Build and Push
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/demo-dapp/security/code-scanning/1](https://github.com/Dargon789/demo-dapp/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that scopes the `GITHUB_TOKEN` to the minimal rights needed. Since this workflow only checks out code, installs dependencies, builds, and then pushes build artifacts back to the current repository, it only needs permission to read and write repository contents. No other GitHub APIs (issues, pull requests, etc.) are used.

The best targeted fix without changing functionality is to add a `permissions:` block under the `build` job (so it affects only this job) with `contents: write`. This is the minimum required for `s0/git-publish-subdir-action` to push to the `build` branch, while avoiding granting broader scopes like `actions`, `issues`, or `pull-requests`. Concretely, in `.github/workflows/build.yml`, directly under `build:` (before `runs-on:`) add:

```yaml
    permissions:
      contents: write
```

No imports or additional methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add an explicit permissions block to the build workflow to grant only contents: write for the build job.